### PR TITLE
Add GA STM env option

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,6 +355,11 @@ config.environment.use_rk4 = True
 config.environment.dt = 15.0  # 더 작은 시간 간격
 ```
 
+3. **GA STM 전파기 사용**
+```python
+config.environment.use_gastm = True
+```
+
 ## Docker 사용법
 
 ### 빌드 및 실행

--- a/config/settings.py
+++ b/config/settings.py
@@ -46,6 +46,7 @@ class EnvironmentConfig:
     max_delta_v_budget: float = ENV_PARAMS["max_delta_v_budget"]
     max_initial_separation: float = ENV_PARAMS["max_initial_separation"]
     use_rk4: bool = ENV_PARAMS["use_rk4"]
+    use_gastm: bool = ENV_PARAMS["use_gastm"]
 
     # 버퍼 설정
     capture_buffer_steps: int = BUFFER_PARAMS["capture_buffer_steps"]

--- a/environment/__init__.py
+++ b/environment/__init__.py
@@ -4,8 +4,10 @@
 """
 
 from .pursuit_evasion_env import PursuitEvasionEnv
+from .pursuit_evasion_env_ga_stm import PursuitEvasionEnvGASTM
 
 __all__ = [
-    'PursuitEvasionEnv'
+    'PursuitEvasionEnv',
+    'PursuitEvasionEnvGASTM'
 ]
 

--- a/main.py
+++ b/main.py
@@ -16,6 +16,7 @@ if not os.environ.get('DEBUG'):
 # 프로젝트 모듈 임포트
 from config.settings import get_config, ProjectConfig
 from environment.pursuit_evasion_env import PursuitEvasionEnv
+from environment.pursuit_evasion_env_ga_stm import PursuitEvasionEnvGASTM
 from training.trainer import SACTrainer, create_trainer
 from training.nash_equilibrium import NashEquilibriumTrainer, train_nash_equilibrium_model
 from analysis.evaluator import ModelEvaluator, create_evaluator
@@ -35,7 +36,10 @@ def setup_environment(config: ProjectConfig) -> PursuitEvasionEnv:
     else:
         print("CPU 모드로 실행")
     
-    env = PursuitEvasionEnv(config)
+    if config.environment.use_gastm:
+        env = PursuitEvasionEnvGASTM(config)
+    else:
+        env = PursuitEvasionEnv(config)
     print(f"환경 초기화 완료")
     print(f"  - 관측 공간: {env.observation_space}")
     print(f"  - 액션 공간: {env.action_space}")
@@ -48,6 +52,8 @@ def create_parallel_env(config: ProjectConfig):
     n_envs = config.training.n_envs
     
     def make_env():
+        if config.environment.use_gastm:
+            return PursuitEvasionEnvGASTM(config)
         return PursuitEvasionEnv(config)
     
     # Windows에서는 DummyVecEnv 사용

--- a/tests/test_environment.py
+++ b/tests/test_environment.py
@@ -6,6 +6,7 @@
 import pytest
 import numpy as np
 from environment.pursuit_evasion_env import PursuitEvasionEnv
+from environment.pursuit_evasion_env_ga_stm import PursuitEvasionEnvGASTM
 from config.settings import get_config
 
 
@@ -82,3 +83,12 @@ class TestPursuitEvasionEnv:
         # 포획 상황에서는 버퍼 시간이 필요하므로 즉시 종료되지 않을 수 있음
         # 단지 시스템이 크래시하지 않는지만 확인
         assert not np.isnan(obs).any()
+
+    def test_gastm_environment_creation(self):
+        """GA STM 환경 생성 테스트"""
+        config = get_config(debug_mode=True)
+        config.environment.use_gastm = True
+        env = PursuitEvasionEnvGASTM(config)
+        obs = env.reset()
+        assert obs.shape == (9,)
+        env.close()

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -36,6 +36,7 @@ ENV_PARAMS = {
     "max_delta_v_budget": 300.0,  # 최대 추진제 예산 (m/s)
     "max_initial_separation": 5e3,  # 최대 초기 분리 거리 (m)
     "use_rk4": True,
+    "use_gastm": False,
 }
 
 # 버퍼 시간 설정


### PR DESCRIPTION
## Summary
- support GA STM environment in config and main logic
- document how to enable GA STM propagation
- expose `PursuitEvasionEnvGASTM` in the package
- test GA STM environment creation

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687da75e56a48330b345753ba01bba57