### PR TITLE
Fix GA STM example config access

### DIFF
--- a/environment/pursuit_evasion_env_ga_stm.py
+++ b/environment/pursuit_evasion_env_ga_stm.py
@@ -314,7 +314,7 @@ if __name__ == "__main__":
     
     # 설정 로드
     config = get_config()
-    config['dt'] = 10.0  # 10초 시간 간격
+    config.environment.dt = 10.0  # 10초 시간 간격
     
     # GA STM 사용 환경 생성
     print("GA STM 환경 생성 중...")


### PR DESCRIPTION
## Summary
- use dataclass config access in `pursuit_evasion_env_ga_stm`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_687dbb62c7588330bb65c83c16f89038