### PR TITLE
Add plotly-based trajectory option

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ numpy>=1.21.0,<1.24.0
 scipy>=1.7.0,<1.11.0
 matplotlib>=3.4.0,<3.8.0
 numba>=0.56.0,<0.58.0
+plotly>=5.17.0
 
 # Data Handling
 pandas>=1.3.0,<2.0.0


### PR DESCRIPTION
## Summary
- add `plot_eci_trajectories` option to export interactive Plotly HTML
- scatter actual points along the trajectory
- support plotly installation via requirements update
- refine color mapping and markers for points

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_68872368c334833089fab7a390f09136