### PR TITLE
Add delta-v options for evaluation & log delta-v data

### DIFF
--- a/analysis/evaluator.py
+++ b/analysis/evaluator.py
@@ -321,6 +321,24 @@ class ModelEvaluator:
                 save_path=f"{save_dir}/test_{scenario_id}_eci",
                 title=f"Test {scenario_id} ECI Trajectory"
             )
+
+        # Delta-V 기록 저장
+        if 'ephemeris_eci' in scenario_result:
+            times = scenario_result['ephemeris_eci'][0]
+        else:
+            times = np.arange(len(actions_e)) * self.env.dt
+
+        delta_v_data = {
+            'time': times.tolist(),
+            'evader_delta_v': actions_e.tolist(),
+            'evader_delta_v_norm': np.linalg.norm(actions_e, axis=1).tolist(),
+            'pursuer_delta_v': actions_p.tolist(),
+            'pursuer_delta_v_norm': np.linalg.norm(actions_p, axis=1).tolist(),
+        }
+
+        with open(f"{save_dir}/test_{scenario_id}_delta_v.json", "w") as f:
+            import json
+            json.dump(delta_v_data, f, indent=2)
     
     def _save_evaluation_results(self, comprehensive_results: Dict,
                                results: List[Dict],
@@ -385,7 +403,11 @@ class ModelEvaluator:
         with open(f"{save_dir}/detailed_results.txt", "w") as f:
             for i, result in enumerate(results):
                 f.write(f"\n=== 테스트 {i+1} ===\n")
+                seen = set()
                 for key, value in result.items():
+                    if key in seen:
+                        continue
+                    seen.add(key)
                     f.write(f"{key}: {value}\n")
     
     def _save_zero_sum_metrics(self, zero_sum_metrics: Dict, save_dir: str):

--- a/main.py
+++ b/main.py
@@ -275,13 +275,31 @@ def interactive_mode():
             
             n_tests = input("테스트 수 (기본값: 10): ").strip()
             n_tests = int(n_tests) if n_tests else 10
-            
+
             # 평가 시에도 GA-STM 옵션 제공
             use_gastm = input("평가 시 GA-STM 사용? (y/n, 기본값: n): ").strip().lower()
-            
+
             config = get_config(experiment_name="interactive_evaluation")
             config.environment.use_gastm = use_gastm == 'y'
-            
+
+            # Delta-V 설정 입력
+            delta_v_emax = input(
+                f"회피자 최대 Delta-V (기본값: {config.environment.delta_v_emax} m/s): "
+            ).strip()
+            if delta_v_emax:
+                config.environment.delta_v_emax = float(delta_v_emax)
+
+            delta_v_pmax = input(
+                f"추격자 최대 Delta-V (기본값: {config.environment.delta_v_pmax} m/s): "
+            ).strip()
+            if delta_v_pmax:
+                config.environment.delta_v_pmax = float(delta_v_pmax)
+
+            print("\n평가 설정:")
+            print(f"  GA-STM 사용: {config.environment.use_gastm}")
+            print(f"  회피자 최대 Delta-V: {config.environment.delta_v_emax} m/s")
+            print(f"  추격자 최대 Delta-V: {config.environment.delta_v_pmax} m/s")
+
             evaluate_model(model_path, config, n_tests)
             
         elif choice == '3' or choice == 'demo':


### PR DESCRIPTION
## Summary
- allow setting delta-v limits during interactive evaluation
- save delta-v time history as JSON when evaluating
- avoid duplicated keys when writing detailed_results.txt

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688871b9a3ec83309f9296f7273f96e4