### PR TITLE
Use constant for Earth radius

### DIFF
--- a/analysis/visualization.py
+++ b/analysis/visualization.py
@@ -13,7 +13,7 @@ import os
 import json
 import csv
 
-from utils.constants import PLOT_PARAMS, SAFETY_THRESHOLDS
+from utils.constants import PLOT_PARAMS, SAFETY_THRESHOLDS, R_EARTH
 
 
 def setup_matplotlib():
@@ -656,9 +656,9 @@ def plot_eci_trajectories(times: np.ndarray,
     if show_earth:
         u = np.linspace(0, 2 * np.pi, 30)
         v = np.linspace(0, np.pi, 20)
-        x_earth = 6378e3 * np.outer(np.cos(u), np.sin(v))  # 미터 단위
-        y_earth = 6378e3 * np.outer(np.sin(u), np.sin(v))
-        z_earth = 6378e3 * np.outer(np.ones(np.size(u)), np.cos(v))
+        x_earth = R_EARTH * np.outer(np.cos(u), np.sin(v))  # 미터 단위
+        y_earth = R_EARTH * np.outer(np.sin(u), np.sin(v))
+        z_earth = R_EARTH * np.outer(np.ones(np.size(u)), np.cos(v))
         ax.plot_surface(x_earth, y_earth, z_earth, color='grey', alpha=0.3)
     
     # 축 설정
@@ -698,8 +698,8 @@ def plot_eci_trajectories(times: np.ndarray,
         final_dist = np.linalg.norm(evader_states[-1, :3] - pursuer_states[-1, :3])
         
         # 평균 고도
-        evader_alt = np.mean(np.linalg.norm(evader_states[:, :3], axis=1)) - 6378e3
-        pursuer_alt = np.mean(np.linalg.norm(pursuer_states[:, :3], axis=1)) - 6378e3
+        evader_alt = np.mean(np.linalg.norm(evader_states[:, :3], axis=1)) - R_EARTH
+        pursuer_alt = np.mean(np.linalg.norm(pursuer_states[:, :3], axis=1)) - R_EARTH
         
         textstr = f'Initial Distance: {initial_dist/1000:.1f} km\n'
         textstr += f'Final Distance: {final_dist/1000:.1f} km\n'
@@ -863,9 +863,9 @@ def _plot_eci_trajectories_plotly(times: np.ndarray,
         u = np.linspace(0, 2 * np.pi, 30)
         v = np.linspace(0, np.pi, 20)
         # 지구 반지름을 km 단위로 사용
-        x_earth = 6378 * np.outer(np.cos(u), np.sin(v))
-        y_earth = 6378 * np.outer(np.sin(u), np.sin(v))
-        z_earth = 6378 * np.outer(np.ones(np.size(u)), np.cos(v))
+        x_earth = (R_EARTH / 1000) * np.outer(np.cos(u), np.sin(v))
+        y_earth = (R_EARTH / 1000) * np.outer(np.sin(u), np.sin(v))
+        z_earth = (R_EARTH / 1000) * np.outer(np.ones(np.size(u)), np.cos(v))
         fig.add_trace(
             go.Surface(
                 x=x_earth, 
@@ -900,8 +900,8 @@ def _plot_eci_trajectories_plotly(times: np.ndarray,
     if show_stats:
         initial_dist = np.linalg.norm(evader_states[0, :3] - pursuer_states[0, :3])
         final_dist = np.linalg.norm(evader_states[-1, :3] - pursuer_states[-1, :3])
-        evader_alt = np.mean(np.linalg.norm(evader_states[:, :3], axis=1)) - 6378e3
-        pursuer_alt = np.mean(np.linalg.norm(pursuer_states[:, :3], axis=1)) - 6378e3
+        evader_alt = np.mean(np.linalg.norm(evader_states[:, :3], axis=1)) - R_EARTH
+        pursuer_alt = np.mean(np.linalg.norm(pursuer_states[:, :3], axis=1)) - R_EARTH
         
         textstr = f"Initial Distance: {initial_dist/1000:.1f} km<br>"
         textstr += f"Final Distance: {final_dist/1000:.1f} km<br>"

--- a/examples/custom_configuration.py
+++ b/examples/custom_configuration.py
@@ -6,6 +6,7 @@
 from config.settings import get_config, ProjectConfig
 from environment.pursuit_evasion_env import PursuitEvasionEnv
 from training.trainer import create_trainer
+from utils.constants import R_EARTH
 
 
 def create_custom_config() -> ProjectConfig:
@@ -45,7 +46,7 @@ def main():
     
     # 2. 설정 정보 출력
     print(f"실험 이름: {config.experiment_name}")
-    print(f"궤도 고도: {(config.orbit.a - 6378e3)/1000:.0f} km")
+    print(f"궤도 고도: {(config.orbit.a - R_EARTH)/1000:.0f} km")
     print(f"최대 스텝: {config.environment.max_steps}")
     print(f"학습률: {config.training.learning_rate}")
     


### PR DESCRIPTION
## Summary
- reference the Earth radius constant instead of numeric literals
- show altitude using the constant in the example configuration

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'torch')*

------
https://chatgpt.com/codex/tasks/task_e_688b1b8d37508330ad151c59bdc1b5d2