### PR TITLE
Migrate environment to Gymnasium API

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,10 +122,11 @@ print(f"액션 공간: {env.action_space}")
 print(f"관측 공간: {env.observation_space}")
 
 # 랜덤 에피소드 실행
-obs = env.reset()
+obs, info = env.reset()
 for _ in range(100):
     action = env.action_space.sample()
-    obs, reward, done, info = env.step(action)
+    obs, reward, terminated, truncated, info = env.step(action)
+    done = terminated or truncated
     if done:
         print(f"에피소드 종료: {info['outcome']}")
         break
@@ -335,7 +336,7 @@ config.training.verbose = 2
 ```python
 # 단계별 상태 출력
 env = PursuitEvasionEnv(config)
-obs = env.reset()
+obs, _ = env.reset()
 print(f"초기 상태: {env.state}")
 print(f"초기 거리: {np.linalg.norm(env.state[:3]):.0f}m")
 ```

--- a/analysis/evaluator.py
+++ b/analysis/evaluator.py
@@ -142,7 +142,7 @@ class ModelEvaluator:
         Returns:
             시나리오 실행 결과
         """
-        obs = self.env.reset()
+        obs, _ = self.env.reset()
         done = False
 
         # 데이터 수집
@@ -160,7 +160,8 @@ class ModelEvaluator:
             normalized_action, _ = self.model.predict(obs, deterministic=deterministic)
             
             # 환경 스텝
-            obs, reward, done, info = self.env.step(normalized_action)
+            obs, reward, terminated, truncated, info = self.env.step(normalized_action)
+            done = terminated or truncated
             step_count += 1
 
             # 보상 기록

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@
 torch==2.6.0+cu124     # GPU 보장 필요로 예외적으로 고정
 stable-baselines3>=2.7.0a1,<2.8.0a0
 gymnasium>=1.1.0,<2.0.0
-gym>=0.26,<0.27
 shimmy>=2.0.0,<2.1.0
 
 # Scientific Computing

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,17 +47,18 @@ class TestIntegration:
         env = PursuitEvasionEnv(config)
         
         # 환경 리셋
-        obs = env.reset()
+        obs, _ = env.reset()
         
         # 액션 공간 확인
         action = env.action_space.sample()
         
         # 스텝 실행
-        next_obs, reward, done, info = env.step(action)
+        next_obs, reward, terminated, truncated, info = env.step(action)
+        done = terminated or truncated
         
         # 기본 호환성 확인
         assert obs.shape == env.observation_space.shape
         assert action.shape == env.action_space.shape
         assert next_obs.shape == env.observation_space.shape
-        
+
         env.close()

--- a/training/nash_equilibrium.py
+++ b/training/nash_equilibrium.py
@@ -113,15 +113,16 @@ class NashEquilibriumTrainer(SACTrainer):
         strategy_performance = []
         
         for episode in range(episodes):
-            obs = self.env.reset()
+            obs, _ = self.env.reset()
             done = False
             episode_reward = 0
-            
+
             # 에피소드 실행
             while not done:
                 # 회피자 액션 (현재 정책 사용)
                 action, _ = self.model.predict(obs, deterministic=True)
-                obs, reward, done, info = self.env.step(action)
+                obs, reward, terminated, truncated, info = self.env.step(action)
+                done = terminated or truncated
                 episode_reward += reward
             
             # 결과 기록

--- a/training/trainer.py
+++ b/training/trainer.py
@@ -336,14 +336,15 @@ class SACTrainer:
             eval_env = PursuitEvasionEnv(self.config)
 
         for episode in range(n_episodes):
-            obs = eval_env.reset()
+            obs, _ = eval_env.reset()
             episode_reward = 0
             episode_length = 0
             done = False
 
             while not done:
                 action, _ = self.model.predict(obs, deterministic=deterministic)
-                obs, reward, done, info = eval_env.step(action)
+                obs, reward, terminated, truncated, info = eval_env.step(action)
+                done = terminated or truncated
                 episode_reward += reward
                 episode_length += 1
 


### PR DESCRIPTION
## Summary
- replace OpenAI Gym imports with Gymnasium
- update environment, utilities and training loops for new reset and step signatures
- adjust tests and documentation to reflect Gymnasium API

## Testing
- `pre-commit run --files README.md analysis/evaluator.py environment/pursuit_evasion_env.py environment/pursuit_evasion_env_ga_stm.py requirements.txt tests/test_environment.py tests/test_integration.py training/nash_equilibrium.py training/trainer.py utils/optimization.py` *(fails: InvalidConfigError: expected a single document in the stream)*
- `pytest tests/test_environment.py tests/test_integration.py` *(fails: ModuleNotFoundError: No module named 'utils')*


------
https://chatgpt.com/codex/tasks/task_e_68bf89fdb4f48330ba8260632bd2565a